### PR TITLE
(minor) `Date` export conflicts with native `Date` constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ export const mixin = function (helpers, superclass) {
 };
 
 import * as Template from './lib/template';
-import * as Date from './lib/date';
+import * as DateUtils from './lib/date';
 import * as Money from './lib/money';
 
-export { Template, Date, Money };
+// TODO remove deprecated Date export [issue #34]
+export { Template, DateUtils, Money, DateUtils as Date };


### PR DESCRIPTION
Renamed export to `DateUtils`, marked `Date` export as deprecated; to be removed in a future major release.