### PR TITLE
ci: test if setup-node problem matcher for eslint works

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,9 +26,7 @@ jobs:
       run: npx commitlint --from origin/master --to HEAD
 
     - name: ESLint
-      run: npx github-actions-eslint-annotator
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: npm run lint
 
     - name: Test and report
       env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1367,15 +1367,6 @@
 				}
 			}
 		},
-		"@neovici/github-actions-eslint-annotator": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@neovici/github-actions-eslint-annotator/-/github-actions-eslint-annotator-0.4.0.tgz",
-			"integrity": "sha512-+shjKgFwBW5joR/5BgJQvLi+yx40tr28VSfRHVaBQFnzzZVlOkljB37J3OmzLgxm8XpxBey42duwn9a9rwRy0w==",
-			"dev": true,
-			"requires": {
-				"eslint": ">=5"
-			}
-		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
 		"@formatjs/intl-pluralrules": "^1.5.3",
 		"@formatjs/intl-relativetimeformat": "^4.5.10",
 		"@neovici/eslint-config": "^1.2.0",
-		"@neovici/github-actions-eslint-annotator": "^0.4.0",
 		"@open-wc/testing": "^2.5.6",
 		"@open-wc/testing-karma": "^3.3.7",
 		"@polymer/polymer": "^3.3.1",


### PR DESCRIPTION
Annotating the eslint errors and warnings to the PR is built into the setup-node task, so no need to run a separate task for this.