### PR TITLE
fix: adds ignored files to release

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"access": "public"
 	},
 	"files": [
-		"lib/*.js"
+		"lib/**/*.js"
 	],
 	"commitlint": {
 		"extends": [


### PR DESCRIPTION
`lib/reduce/*.js` files are currently ignored