### PR TITLE
feat(portal): new directive for rendering parts in remote outlets

### DIFF
--- a/lib/directives/portal.js
+++ b/lib/directives/portal.js
@@ -1,0 +1,43 @@
+import {
+	directive, NodePart
+} from 'lit-html';
+
+const destroyOutlet = part => {
+	part._outletPart.clear();
+	part._outletPart.commit();
+
+	const parent = part._outletPart.startNode.parentNode;
+	parent.removeChild(part._outletPart.startNode);
+	parent.removeChild(part._outletPart.endNode);
+	part._outletPart = undefined;
+};
+
+export const
+	// eslint-disable-next-line max-statements
+	portal = directive((content, outlet = document.body) => part => {
+		if (part._outletPart && part._outlet !== outlet) {
+			destroyOutlet(part);
+		}
+
+		if (!part._outletPart) {
+			// Create a new part to be used as output of this directive.
+			part._outletPart = new NodePart(part.options);
+			part._outletPart.appendInto(outlet);
+			part._outlet = outlet;
+		}
+
+		// Update the outlet's content.
+		part._outletPart.setValue(content);
+		part._outletPart.commit();
+
+		// Run in an animation frame, so the DOM changes finish commiting.
+		requestAnimationFrame(() => requestAnimationFrame(() => {
+			// If the origin part is no longer connected
+			// clear the outlet part and clean up the marker nodes.
+			if (part.startNode.isConnected || !part._outletPart) {
+				return;
+			}
+
+			destroyOutlet(part);
+		}));
+	});

--- a/test/directive-portal.test.js
+++ b/test/directive-portal.test.js
@@ -1,0 +1,86 @@
+import { component } from 'haunted';
+import {
+	assert,
+	html,
+	fixture,
+	nextFrame
+} from '@open-wc/testing';
+import { portal } from '../lib/directives/portal';
+
+customElements.define(
+	'test-portal',
+	component(({
+		value,
+		target
+	}) => {
+		return html`${ portal(html`<span class="portal-outlet">${ value }</span>`, target) }`;
+	})
+);
+
+
+suite('portal', () => {
+	setup(async () => {
+		// wait two frames between tests so the outlet is cleaned up
+		await nextFrame();
+		await nextFrame();
+	});
+
+	test('renders in body', async () => {
+		const component = await fixture(html`<test-portal .value=${ 1 } />`);
+
+		assert.equal(document.querySelector('body > .portal-outlet').textContent, 1);
+
+		component.value = 2;
+		await nextFrame(); // it takes one frame for the content to be updated
+
+		assert.equal(document.querySelector('body > .portal-outlet').textContent, 2);
+	});
+
+	test('cleans up when removed', async () => {
+		const component = await fixture(html`<test-portal .value=${ 1 } />`);
+		assert.equal(document.querySelector('body > .portal-outlet').textContent, 1);
+
+		component.parentNode.removeChild(component);
+
+		// it takes two frames for the outlet to be cleaned up
+		await nextFrame();
+		await nextFrame();
+
+		assert.isNull(document.querySelector('body > .portal-outlet'));
+	});
+
+	test('renders in other element', async () => {
+		const
+			target = await fixture(html`<span></span>`),
+			component = await fixture(html`<test-portal .value=${ 1 } .target="${ target }"/>`);
+
+		assert.equal(target.querySelector('.portal-outlet').textContent, 1);
+
+		component.value = 2;
+		await nextFrame();
+
+		assert.equal(target.querySelector('.portal-outlet').textContent, 2);
+
+		component.parentNode.removeChild(component);
+		await nextFrame();
+		await nextFrame();
+
+		assert.isNull(target.querySelector('.portal-outlet'));
+	});
+
+	test('can switch outlet element', async () => {
+		const
+			target = await fixture(html`<span></span>`),
+			target2 = await fixture(html`<span></span>`),
+			component = await fixture(html`<test-portal .value=${ 1 } .target="${ target }"/>`);
+
+		assert.equal(target.querySelector('.portal-outlet').textContent, 1);
+		assert.isNull(target2.querySelector('.portal-outlet'));
+
+		component.target = target2;
+		await nextFrame();
+
+		assert.isNull(target.querySelector('.portal-outlet'));
+		assert.equal(target2.querySelector('.portal-outlet').textContent, 1);
+	});
+});


### PR DESCRIPTION
Useful for dialogs, dropdowns, anything that needs to be rendered outside of the scope of the component, but you still want to control the content from within the component.