### PR TITLE
fix(portal): outlet part is not cleaned up

### DIFF
--- a/lib/directives/portal.js
+++ b/lib/directives/portal.js
@@ -1,5 +1,5 @@
 import {
-	directive, NodePart
+	directive, NodePart, html
 } from 'lit-html';
 
 const destroyOutlet = part => {
@@ -12,32 +12,42 @@ const destroyOutlet = part => {
 	part._outletPart = undefined;
 };
 
+/**
+ * Helper element with a customizable disconnect behavior.
+ */
+class DisconnectObserver extends HTMLElement {
+	disconnectedCallback() {
+		this.onDisconnect();
+	}
+}
+
+customElements.define('disconnect-observer', DisconnectObserver);
+
 export const
 	// eslint-disable-next-line max-statements
-	portal = directive((content, outlet = document.body) => part => {
-		if (part._outletPart && part._outlet !== outlet) {
-			destroyOutlet(part);
+	portal = directive((content, outlet = document.body) => sourcePart => {
+		// Initialize a disconnect-observer element that cleans up the outletPart when the sourcePart is removed from DOM.
+		if (!sourcePart._portalCleanerSetUp) {
+			sourcePart._portalCleanerSetUp = true;
+			sourcePart.setValue(html`<disconnect-observer .onDisconnect="${ () => {
+				destroyOutlet(sourcePart);
+				sourcePart._portalCleanerSetUp = undefined;
+			} }">`);
 		}
 
-		if (!part._outletPart) {
-			// Create a new part to be used as output of this directive.
-			part._outletPart = new NodePart(part.options);
-			part._outletPart.appendInto(outlet);
-			part._outlet = outlet;
+		// Clean up a previously set up outletPart if the outlet target has changed
+		if (sourcePart._outletPart && sourcePart._outlet !== outlet) {
+			destroyOutlet(sourcePart);
+		}
+
+		if (!sourcePart._outletPart) {
+			// Create a new sourcePart to be used as output of this directive.
+			sourcePart._outletPart = new NodePart(sourcePart.options);
+			sourcePart._outletPart.appendInto(outlet);
+			sourcePart._outlet = outlet;
 		}
 
 		// Update the outlet's content.
-		part._outletPart.setValue(content);
-		part._outletPart.commit();
-
-		// Run in an animation frame, so the DOM changes finish commiting.
-		requestAnimationFrame(() => requestAnimationFrame(() => {
-			// If the origin part is no longer connected
-			// clear the outlet part and clean up the marker nodes.
-			if (part.startNode.isConnected || !part._outletPart) {
-				return;
-			}
-
-			destroyOutlet(part);
-		}));
+		sourcePart._outletPart.setValue(content);
+		sourcePart._outletPart.commit();
 	});

--- a/test/directive-portal.test.js
+++ b/test/directive-portal.test.js
@@ -19,12 +19,6 @@ customElements.define(
 
 
 suite('portal', () => {
-	setup(async () => {
-		// wait two frames between tests so the outlet is cleaned up
-		await nextFrame();
-		await nextFrame();
-	});
-
 	test('renders in body', async () => {
 		const component = await fixture(html`<test-portal .value=${ 1 } />`);
 
@@ -42,10 +36,6 @@ suite('portal', () => {
 
 		component.parentNode.removeChild(component);
 
-		// it takes two frames for the outlet to be cleaned up
-		await nextFrame();
-		await nextFrame();
-
 		assert.isNull(document.querySelector('body > .portal-outlet'));
 	});
 
@@ -62,9 +52,6 @@ suite('portal', () => {
 		assert.equal(target.querySelector('.portal-outlet').textContent, 2);
 
 		component.parentNode.removeChild(component);
-		await nextFrame();
-		await nextFrame();
-
 		assert.isNull(target.querySelector('.portal-outlet'));
 	});
 
@@ -77,10 +64,11 @@ suite('portal', () => {
 		assert.equal(target.querySelector('.portal-outlet').textContent, 1);
 		assert.isNull(target2.querySelector('.portal-outlet'));
 
+		component.value = 2;
 		component.target = target2;
 		await nextFrame();
 
 		assert.isNull(target.querySelector('.portal-outlet'));
-		assert.equal(target2.querySelector('.portal-outlet').textContent, 1);
+		assert.equal(target2.querySelector('.portal-outlet').textContent, 2);
 	});
 });


### PR DESCRIPTION
The requestAnimationFrame solution for cleanup is not reliable, because it only catches disconnects that happen immediately after the directive is last called.
A better solution is to add a tiny helper element in the sourcePart, that does the cleanup when it is disconnected.