### PR TITLE
fix(portal): outlet is not cleaned up correctly if sourcePart is destroyed quick enough

### DIFF
--- a/lib/directives/portal.js
+++ b/lib/directives/portal.js
@@ -3,8 +3,11 @@ import {
 } from 'lit-html';
 
 const destroyOutlet = part => {
+	if (!part._outletPart) {
+		return;
+	}
+
 	part._outletPart.clear();
-	part._outletPart.commit();
 
 	const parent = part._outletPart.startNode.parentNode;
 	parent.removeChild(part._outletPart.startNode);
@@ -40,11 +43,28 @@ export const
 			destroyOutlet(sourcePart);
 		}
 
+		// Create a new sourcePart to be used as output of this directive.
 		if (!sourcePart._outletPart) {
-			// Create a new sourcePart to be used as output of this directive.
-			sourcePart._outletPart = new NodePart(sourcePart.options);
-			sourcePart._outletPart.appendInto(outlet);
-			sourcePart._outlet = outlet;
+			// Use a microtask so the disconnect-observer has time to initialize.
+			queueMicrotask(() => {
+				// Don't create the outletPart if the sourcePart is not connected.
+				if (!sourcePart.startNode.isConnected) {
+					return;
+				}
+
+				// Due to use of microtask, we have to make sure the outlet isn't initialized twice.
+				if (sourcePart._outletPart) {
+					return;
+				}
+
+				sourcePart._outletPart = new NodePart(sourcePart.options);
+				sourcePart._outletPart.appendInto(outlet);
+				sourcePart._outletPart.setValue(content);
+				sourcePart._outletPart.commit();
+				sourcePart._outlet = outlet;
+			});
+
+			return;
 		}
 
 		// Update the outlet's content.


### PR DESCRIPTION
I ran into this issue while switching views in FE.