### PR TITLE
feat(haunted-polymer): use setProperties instead of outputPath

### DIFF
--- a/lib/haunted-polymer.js
+++ b/lib/haunted-polymer.js
@@ -16,48 +16,60 @@ class Scheduler extends BaseScheduler {
 /**
  * Creates a mixin that mixes a haunted hook with a polymer component.
  *
- * @param {String} outputPath The property where the result of the hook will be stored
+ * @param {String} outputPath The property where the result of the hook will be stored (deprecated)
  * @param {Function} hook A haunted hook
  * @returns {Function} The mixin
  */
-export const hauntedPolymer = (outputPath, hook) => base => class extends base {
-	constructor() {
-		super();
-		this._scheduler = new Scheduler( // whenever the state is updated
-			() => hook(this), // run the hook with the element as input
-			this, // using the element as state host
-			result => this.set(outputPath, result) // and update the output path with the results
-		);
+export const hauntedPolymer = (outputPath, hook) => base => {
+	const hasOutputPath = hook !== undefined,
+		_hook = hasOutputPath ? hook : outputPath;
+
+	// TODO: drop outputPath support after all usages are fixed.
+	if (hasOutputPath) {
+		// eslint-disable-next-line no-console
+		console.warn('Haunted Polymer: use of outputPath is deprecated. Instead have the hook return an object with the keys being property names to update.');
 	}
 
-	connectedCallback() {
-		super.connectedCallback();
-		this._scheduler.update();
-	}
+	return class extends base {
+		constructor() {
+			super();
 
-	disconnectedCallback() {
-		super.disconnectedCallback();
-		this._scheduler.teardown();
-	}
-
-	_propertiesChanged(currentProps, changedProps, oldProps) {
-		super._propertiesChanged(currentProps, changedProps, oldProps);
-
-		// skip haunted state update if the only thing that has changed is the hook output path
-		if (Object.keys(changedProps).length === 1 && changedProps[outputPath] != null) {
-			return;
+			this._scheduler = new Scheduler( // whenever the state is updated
+				() => _hook(this), // run the hook with the element as input
+				this, // using the element as state host
+				result => hasOutputPath ? this.set(outputPath, result) : this.setProperties(result) // and update the output path with the results
+			);
 		}
 
-		// trigger a haunted update loop
-		// do it in the next animation frame, so the current loop finishes processing first
-		cancelAnimationFrame(this._hauntedUpdateFrameHandle);
-		this._hauntedUpdateFrameHandle = requestAnimationFrame(() => this._scheduler.update());
-	}
+		connectedCallback() {
+			super.connectedCallback();
+			this._scheduler.update();
+		}
 
-	renderLitTo(part, outlet) {
-		// render in the next animation frame to allow the haunted scheduler to finish processing the current state update
-		// otherwise hooks might be updated twice
-		cancelAnimationFrame(outlet.__renderAF);
-		outlet.__renderAF = requestAnimationFrame(() => render(part, outlet));
-	}
+		disconnectedCallback() {
+			super.disconnectedCallback();
+			this._scheduler.teardown();
+		}
+
+		_propertiesChanged(currentProps, changedProps, oldProps) {
+			super._propertiesChanged(currentProps, changedProps, oldProps);
+
+			// skip haunted state update if the only thing that has changed is the hook output path
+			if (hasOutputPath && Object.keys(changedProps).length === 1 && changedProps[outputPath] != null) {
+				return;
+			}
+
+			// trigger a haunted update loop
+			// do it in the next animation frame, so the current loop finishes processing first
+			cancelAnimationFrame(this._hauntedUpdateFrameHandle);
+			this._hauntedUpdateFrameHandle = requestAnimationFrame(() => this._scheduler.update());
+		}
+
+		renderLitTo(part, outlet) {
+			// render in the next animation frame to allow the haunted scheduler to finish processing the current state update
+			// otherwise hooks might be updated twice
+			cancelAnimationFrame(outlet.__renderAF);
+			outlet.__renderAF = requestAnimationFrame(() => render(part, outlet));
+		}
+	};
 };

--- a/test/haunted-polymer.test.js
+++ b/test/haunted-polymer.test.js
@@ -90,3 +90,40 @@ suite('haunted polymer render lit', () => {
 		assert.equal(basicFixture.shadowRoot.textContent, 'lit says: bye');
 	});
 });
+
+
+
+const useSum = ({
+	a, b
+}) => {
+	return { sum: useMemo(() => a + b, [a, b]) };
+};
+
+class myCalculator extends hauntedPolymer(useSum)(PolymerElement) {
+	static get properties() {
+		return {
+			a: {
+				type: Number
+			},
+			b: {
+				type: Number
+			}
+		};
+	}
+
+	static get template() {
+		return polymerHtml`[[ a ]] + [[ b ]] = [[ sum ]]`;
+	}
+}
+
+customElements.define('my-calculator', myCalculator);
+
+suite('haunted polymer without outputPath', () => {
+	test('basic', async () => {
+		const calculator = await fixture(html`<my-calculator a="1" b="2"></my-calculator>`);
+		assert.equal(calculator.shadowRoot.textContent, '1 + 2 = 3');
+		calculator.a = 5;
+		await nextFrame();
+		assert.equal(calculator.shadowRoot.textContent, '5 + 2 = 7');
+	});
+});


### PR DESCRIPTION
Setting a single outputPath is very limiting, and causes unnecessary recalculations in polymer when observing subpaths of the outputPath. For example `computed: '_computeFrom(state.invoices)'` results in a new value even if state.invoices did not change, but state.otherProp did.

Migration instructions:

Drop the outputPath from the hauntedPolymer call and move it to the output of the hook:

```js
hook = () => return 'a';

hauntedPolymer('state', hook)
```

becomes

```js
hook = () => return {state: 'a'};

hauntedPolymer(hook)
```