### PR TITLE
fix(use-host-bounds): handle resizes in a frame

### DIFF
--- a/lib/hooks/use-host-bounds.js
+++ b/lib/hooks/use-host-bounds.js
@@ -10,7 +10,7 @@ const useHostBounds = () => {
 		[bounds, setBounds] = useState();
 
 	useLayoutEffect(() => {
-		const observer = new ResizeObserver(entries => setBounds(entries[0]?.contentRect));
+		const observer = new ResizeObserver(entries => requestAnimationFrame(() => setBounds(entries[0]?.contentRect)));
 		observer.observe(host);
 		return () => observer.unobserve(host);
 	}, []);

--- a/test/use-host-bounds.test.js
+++ b/test/use-host-bounds.test.js
@@ -21,6 +21,7 @@ suite('use-host-bounds', () => {
 
 		await nextFrame();
 		await nextFrame();
+		await nextFrame();
 
 		assert.equal(Math.round(result.current.width), 120);
 	});


### PR DESCRIPTION
See https://github.com/WICG/resize-observer/issues/38 but it's a good idea anyway
to update state in a microtask or animation frame