### PR TITLE
fix(renderamount): adds more explicit null check on amount

### DIFF
--- a/lib/money.js
+++ b/lib/money.js
@@ -36,7 +36,7 @@ const CURRENCY_FORMATTERS = {},
 	 * @return {string} Formatted amount.
 	 */
 	renderAmount = function (money, locale) {
-		if (money == null) {
+		if (money?.amount == null) {
 			return;
 		}
 		const formatter = _getCurrencyFormatter(money.currency, locale);

--- a/test/money.test.js
+++ b/test/money.test.js
@@ -155,6 +155,15 @@ suite('money utils', () => {
 		assert.equal(renderAmount(null), undefined);
 		assert.equal(renderAmount(), undefined);
 
+		assert.equal(renderAmount({
+			amount: null,
+			currency: 'USD'
+		}), undefined);
+
+		assert.equal(renderAmount({
+			currency: 'USD'
+		}), undefined);
+
 		assert.isString(renderAmount({
 			amount: 100,
 			currency: 'USD'


### PR DESCRIPTION
In cases the object money exists but the amount itself is null. Currently this results in NaN being rendered to the user, better to render nothing instead. 