### PR TITLE
fix: parse yyyy-mm-dd as local

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -24,6 +24,13 @@ const
 		}
 		return [secDiff, 'second'];
 	},
+	rules = { isoBasic: /^\d{4}-\d{2}-\d{2}$/ui },
+	parse = val => {
+		if (typeof val === 'string' && rules.isoBasic.test(val)) {
+			return new Date(`${ val }T00:00`);
+		}
+		return new Date(val);
+	},
 	/**
 	 * Validate a Date object or date string.
 	 * @param {date/string} date Date to check.
@@ -37,7 +44,7 @@ const
 			return date;
 		}
 
-		const ensuredDate = new Date(date);
+		const ensuredDate = parse(date);
 
 		if (ensuredDate instanceof Date && isNaN(ensuredDate)) {
 			return;


### PR DESCRIPTION
Instead of the default Date behavior which parses date only string as utc parse it as local.
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#date_time_string_format
