### PR TITLE
feat(directives): provide and consume context values

### DIFF
--- a/src/directives/consume.ts
+++ b/src/directives/consume.ts
@@ -1,0 +1,76 @@
+import { Context, ContextDetail } from 'haunted/lib/create-context';
+import { contextEvent } from 'haunted/lib/symbols';
+import { AttributePart, noChange } from 'lit-html';
+import { AsyncDirective, directive } from 'lit-html/async-directive.js';
+import { ChildPart, DirectiveParameters } from 'lit-html/directive.js';
+import { identity } from '../function';
+
+const getEmitter = (part: AttributePart | ChildPart) =>
+	'element' in part ? part.element : part.parentNode;
+
+class ConsumeDirective<T> extends AsyncDirective {
+	value!: T;
+	context!: Context<T>;
+	pluck!: (value: T) => unknown;
+	unsubscribe!: VoidFunction | null;
+	raf!: number;
+
+	update(
+		part: AttributePart | ChildPart,
+		[context, pluck = identity]: DirectiveParameters<this>
+	) {
+		// if the context has changed OR we are not yet subscribed
+		if (this.context !== context || !this.unsubscribe) {
+			this.unsubscribe?.();
+
+			this.context = context;
+			this.pluck = pluck;
+
+			// when first initialized, the element is not part of the DOM
+			// so we attempt to subscribe in the next animation frame
+			cancelAnimationFrame(this.raf);
+			this.raf = requestAnimationFrame(() => this.subscribe(getEmitter(part)));
+
+			return noChange;
+		}
+
+		if (this.pluck === pluck) {
+			return noChange;
+		}
+
+		this.pluck = pluck;
+		return this.render(context, pluck);
+	}
+
+	subscribe(emitter: Node) {
+		const detail = { Context: this.context, callback: this.updater.bind(this) };
+		emitter.dispatchEvent(
+			new CustomEvent(contextEvent, {
+				detail,
+				bubbles: true,
+				cancelable: true,
+				composed: true,
+			})
+		);
+		const { unsubscribe = null, value } = detail as ContextDetail<T>;
+
+		this.value = unsubscribe ? value : this.context.defaultValue;
+		this.unsubscribe = unsubscribe;
+		this.setValue(this.pluck(this.value));
+	}
+
+	render(context: Context<T>, pluck: (value: T) => unknown) {
+		return pluck(this.value);
+	}
+
+	updater(value: T) {
+		this.value = value;
+		this.setValue(this.pluck(this.value));
+	}
+
+	protected disconnected(): void {
+		this.unsubscribe?.();
+	}
+}
+
+export const consume = directive(ConsumeDirective);

--- a/src/directives/provide.ts
+++ b/src/directives/provide.ts
@@ -1,0 +1,61 @@
+import { Context, ContextDetail } from 'haunted/lib/create-context';
+import { contextEvent } from 'haunted/lib/symbols';
+import { noChange, nothing } from 'lit-html';
+import { AsyncDirective, directive } from 'lit-html/async-directive.js';
+import { ChildPart } from 'lit-html/directive.js';
+
+class ProvideDirective<T> extends AsyncDirective {
+	value!: T;
+	context!: Context<T>;
+
+	listeners: Set<(value: T) => void> = new Set();
+	cleanup!: VoidFunction | undefined;
+
+	update(part: ChildPart, [context, value]: [Context<T>, T]) {
+		this.context = context;
+
+		if (this.value !== value) {
+			this.value = value;
+
+			for (const callback of this.listeners) {
+				callback(value);
+			}
+		}
+
+		if (!this.cleanup) {
+			part.parentNode.addEventListener(contextEvent, this);
+			this.cleanup = () =>
+				part.parentNode.removeEventListener(contextEvent, this);
+		}
+
+		return noChange;
+	}
+
+	render() {
+		return nothing;
+	}
+
+	handleEvent(event: CustomEvent<ContextDetail<T>>): void {
+		const { detail } = event;
+
+		if (detail.Context !== this.context) return;
+
+		detail.value = this.value;
+		detail.unsubscribe = this.unsubscribe.bind(this, detail.callback);
+
+		this.listeners.add(detail.callback);
+
+		event.stopPropagation();
+	}
+
+	unsubscribe(callback: (value: T) => void): void {
+		this.listeners.delete(callback);
+	}
+
+	protected disconnected(): void {
+		this.cleanup?.();
+		this.cleanup = undefined;
+	}
+}
+
+export const provide = directive(ProvideDirective);

--- a/test/consume.test.js
+++ b/test/consume.test.js
@@ -1,0 +1,77 @@
+import { assert, fixture, html } from '@open-wc/testing';
+import { createContext } from 'haunted';
+import { consume } from '../src/directives/consume';
+
+const Theme = createContext('light');
+customElements.define('theme-provider', Theme.Provider);
+
+const AppState = createContext({ loggedIn: false });
+customElements.define('app-state-provider', AppState.Provider);
+
+suite('consume directive', () => {
+	test('gives access to the current context value', async () => {
+		const el = await fixture(
+			html`<theme-provider .value=${'light'}>${consume(Theme)}</theme-provider>`
+		);
+		assert.equal(el.textContent, 'light');
+	});
+
+	test('uses the default value if no provider exists', async () => {
+		const el = await fixture(html`<p>${consume(Theme)}</p>`);
+		assert.equal(el.textContent, 'light');
+	});
+
+	test('re-renders when the context value is updated', async () => {
+		const el = await fixture(
+			html`<theme-provider .value=${'light'}>${consume(Theme)}</theme-provider>`
+		);
+		el.value = 'dark';
+		assert.equal(el.textContent, 'dark');
+	});
+
+	test('works for attribute parts', async () => {
+		const el = await fixture(
+			html`<theme-provider .value=${'light'}
+				><h1 theme=${consume(Theme)}>Heading</h1></theme-provider
+			>`
+		);
+		assert.dom.equal(
+			el,
+			`<theme-provider>
+                <h1 theme="light">
+                    Heading
+                </h1>
+            </theme-provider>`
+		);
+
+		el.value = 'dark';
+		assert.dom.equal(
+			el,
+			`<theme-provider>
+                <h1 theme="dark">
+                    Heading
+                </h1>
+            </theme-provider>`
+		);
+	});
+
+	test('you can pluck data from the context', async () => {
+		const el = await fixture(
+			html`<app-state-provider .value=${{ loggedIn: false }}
+				><span>Logged in:</span> ${consume(AppState, ({ loggedIn }) =>
+					loggedIn ? 'Yes' : 'No'
+				)}</app-state-provider
+			>`
+		);
+		assert.dom.equal(
+			el,
+			'<app-state-provider><span>Logged in:</span> No</app-state-provider>'
+		);
+
+		el.value = { loggedIn: true };
+		assert.dom.equal(
+			el,
+			'<app-state-provider><span>Logged in:</span> Yes</app-state-provider>'
+		);
+	});
+});

--- a/test/provide.test.js
+++ b/test/provide.test.js
@@ -1,0 +1,33 @@
+import { assert, fixture, html, nextFrame } from '@open-wc/testing';
+import { component, createContext } from 'haunted';
+import { provide } from '../src/directives/provide';
+
+const Theme = createContext('light');
+customElements.define('theme-consumer', Theme.Consumer);
+
+const ProviderTest = ({ theme }) => html`<p>
+	${provide(Theme, theme)}
+	<theme-consumer .render=${(theme) => theme}></theme-consumer>
+</p>`;
+customElements.define(
+	'provider-test',
+	component(ProviderTest, { useShadowDOM: false })
+);
+
+suite('provide directive', () => {
+	test('provides a context value in the current node hierarchy', async () => {
+		const el = await fixture(
+			html`<provider-test .theme=${'dark'}></provider-test>`
+		);
+		assert.shadowDom.equal(el.querySelector('theme-consumer'), 'dark');
+	});
+
+	test('notifies of value changes', async () => {
+		const el = await fixture(
+			html`<provider-test .theme=${'dark'}></provider-test>`
+		);
+		el.theme = 'colorful';
+		await nextFrame();
+		assert.shadowDom.equal(el.querySelector('theme-consumer'), 'colorful');
+	});
+});


### PR DESCRIPTION
Helper directives for simplifying usage of contexts.
Check out the tests for examples.