### PR TITLE
feat(directives): directive to inject css using adopted stylesheets

### DIFF
--- a/src/directives/adopt.ts
+++ b/src/directives/adopt.ts
@@ -1,0 +1,32 @@
+import {
+	Directive,
+	directive,
+	ElementPart,
+	DirectiveParameters,
+} from 'lit-html/directive.js';
+import { noChange } from 'lit-html';
+
+class AdoptCss extends Directive {
+	stylesheet: CSSStyleSheet | undefined;
+
+	update(part: ElementPart, [stylesheet]: DirectiveParameters<this>) {
+		if (this.stylesheet === stylesheet) return noChange;
+
+		this.stylesheet = stylesheet;
+
+		const shadowRoot = part.element.shadowRoot;
+		if (!shadowRoot) return noChange;
+
+		shadowRoot.adoptedStyleSheets = [
+			...shadowRoot.adoptedStyleSheets,
+			stylesheet,
+		];
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	render(stylesheet: CSSStyleSheet) {
+		return noChange;
+	}
+}
+
+export const adopt = directive(AdoptCss);


### PR DESCRIPTION
Using this directive you can inject any css stylesheet into any web component.

```html
<cosmoz-omnitable
	style="height: 100%"
	${adopt(omnitableStyle)}
>
```

I'm not 100% sure about the name. Maybe `inject` or `injectStyleSheet` would be better. What do you think?