### PR TITLE
feat(object): prop returns the argument if not an object

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -4,16 +4,19 @@ import { identity } from './function';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Rec<K extends PropertyKey = PropertyKey, V = any> = Record<K, V>;
 
+export const isObject = (obj: unknown): obj is object =>
+	obj != null && typeof obj === 'object' && obj.constructor === Object;
+
 export function prop(): typeof identity;
 export function prop(a: '' | null | false | undefined | 0): typeof identity;
 export function prop<K extends PropertyKey>(
-	key?: K
+	key?: K,
 ): <O>(obj: O) => K extends keyof O ? O[K] : undefined;
 export function prop<K extends PropertyKey>(key?: K) {
 	if (!key) {
 		return identity;
 	}
-	return <O>(obj: O) => (obj as Rec<K>)[key];
+	return <O>(obj: O) => (isObject(obj) ? (obj as Rec<K>)[key] : obj);
 }
 
 export const strProp = <K extends PropertyKey>(key?: K) => {
@@ -28,10 +31,10 @@ export const strProp = <K extends PropertyKey>(key?: K) => {
 
 export const transform = <K extends string, V, RK extends PropertyKey, RV>(
 	obj: Record<K, V>,
-	trans: (entries: [Extract<K, string>, V][]) => Iterable<readonly [RK, RV]>
+	trans: (entries: [Extract<K, string>, V][]) => Iterable<readonly [RK, RV]>,
 ) =>
 	Object.fromEntries(
-		trans(Object.entries(obj) as [Extract<K, string>, V][])
+		trans(Object.entries(obj) as [Extract<K, string>, V][]),
 	) as { [key in RK]: RV };
 
 export const omit =
@@ -69,13 +72,10 @@ type Merge<T1, T2> = { [key in Exclude<keyof T1, keyof T2>]: T1[key] } & {
 		: T2[key];
 };
 
-export const isObject = (obj: unknown): obj is object =>
-	obj != null && typeof obj === 'object' && obj.constructor === Object;
-
 export function merge<T1, T2, T3>(
 	a1: T1,
 	a2: T2,
-	a3: T3
+	a3: T3,
 ): Merge<Merge<T1, T2>, T3>;
 export function merge<T1, T2>(a1: T1, b2: T2): Merge<T1, T2>;
 export function merge(...objs: Rec[]): Rec;

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -7,6 +7,7 @@ suite('prop', () => {
 		assert.equal(prop('b')({ b: 2 }), 2);
 		assert.isUndefined(prop('b')({ c: 4 }));
 		assert.equal(prop(''), identity);
+		assert.equal(prop('b')(2), 2);
 	});
 
 	test('strProp', () => {
@@ -27,12 +28,12 @@ suite('merge', () => {
 					a: 1,
 					b: 3,
 				},
-				{ b: 2 }
+				{ b: 2 },
 			),
 			{
 				a: 1,
 				b: 2,
-			}
+			},
 		);
 		assert.deepEqual(
 			merge(
@@ -41,12 +42,12 @@ suite('merge', () => {
 					b: 3,
 				},
 				{ b: 2 },
-				null
+				null,
 			),
 			{
 				a: 1,
 				b: 2,
-			}
+			},
 		);
 	});
 


### PR DESCRIPTION
I think this handling of non-object arguments is more useful than just returning undefined. It makes it similar in use to invoke, which returns the argument if its not a function.