### PR TITLE
fix(object): handle missing obj in prop

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -13,7 +13,7 @@ export function prop<K extends PropertyKey>(key?: K) {
 	if (!key) {
 		return identity;
 	}
-	return <O>(obj: O) => (obj as Rec<K>)[key];
+	return <O>(obj: O) => (obj as Rec<K>)?.[key];
 }
 
 export const strProp = <K extends PropertyKey>(key?: K) => {


### PR DESCRIPTION
Handle missing obj argument in `prop` function.
