### PR TITLE
fix(omit): make it properly infer when the arguments are const

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -35,16 +35,16 @@ export const transform = <K extends string, V, RK extends PropertyKey, RV>(
 	) as { [key in RK]: RV };
 
 export const omit =
-	<K extends PropertyKey>(keys: K[]) =>
-	<T extends Rec>(obj: T): { [key in Exclude<keyof T, K>]: T[key] } => {
+	<const K extends readonly PropertyKey[]>(keys: K) =>
+	<const T extends Rec>(obj: T) => {
 		const ret: Rec = {};
 
 		for (const key in obj) {
-			if (!(keys as PropertyKey[]).includes(key)) {
+			if (!keys.includes(key)) {
 				ret[key] = obj[key];
 			}
 		}
-		return ret as Omit<T, K>;
+		return ret as Omit<T, K[number]>;
 	};
 
 export const props =

--- a/src/object.ts
+++ b/src/object.ts
@@ -7,7 +7,7 @@ export type Rec<K extends PropertyKey = PropertyKey, V = any> = Record<K, V>;
 export function prop(): typeof identity;
 export function prop(a: '' | null | false | undefined | 0): typeof identity;
 export function prop<K extends PropertyKey>(
-	key?: K
+	key?: K,
 ): <O>(obj: O) => K extends keyof O ? O[K] : undefined;
 export function prop<K extends PropertyKey>(key?: K) {
 	if (!key) {
@@ -28,10 +28,10 @@ export const strProp = <K extends PropertyKey>(key?: K) => {
 
 export const transform = <K extends string, V, RK extends PropertyKey, RV>(
 	obj: Record<K, V>,
-	trans: (entries: [Extract<K, string>, V][]) => Iterable<readonly [RK, RV]>
+	trans: (entries: [Extract<K, string>, V][]) => Iterable<readonly [RK, RV]>,
 ) =>
 	Object.fromEntries(
-		trans(Object.entries(obj) as [Extract<K, string>, V][])
+		trans(Object.entries(obj) as [Extract<K, string>, V][]),
 	) as { [key in RK]: RV };
 
 export const omit =
@@ -75,7 +75,7 @@ export const isObject = (obj: unknown): obj is object =>
 export function merge<T1, T2, T3>(
 	a1: T1,
 	a2: T2,
-	a3: T3
+	a3: T3,
 ): Merge<Merge<T1, T2>, T3>;
 export function merge<T1, T2>(a1: T1, b2: T2): Merge<T1, T2>;
 export function merge(...objs: Rec[]): Rec;


### PR DESCRIPTION
Example:

```ts
const r = omit(['a', 'b'])({ a: 1, b: 2, c: 3 })
typeof r.a
//       ^? any
typeof r.b
//       ^? any
typeof r.c
//       ^? 3