### PR TITLE
fix(keybindings): add check function property and exclude checkbox from focus check

### DIFF
--- a/src/keybindings/types.ts
+++ b/src/keybindings/types.ts
@@ -13,6 +13,7 @@ export type KeyBinding = readonly [Matcher, Activity[], Info];
 export type ActivityHandler = {
 	activity: Activity;
 	callback: () => void;
+	check?: () => boolean;
 	element?: () => Element | null | undefined;
 };
 

--- a/src/keybindings/use-keybindings.ts
+++ b/src/keybindings/use-keybindings.ts
@@ -12,7 +12,7 @@ export const useKeybindings = (bindings: readonly KeyBinding[]): RegisterFn => {
 	const meta = useMeta<State>({ bindings });
 
 	useEffect(() => {
-		const handler = (e: KeyboardEvent) => {
+		const keyboardEventHandler = (e: KeyboardEvent) => {
 			if (e.defaultPrevented) {
 				return;
 			}
@@ -27,16 +27,25 @@ export const useKeybindings = (bindings: readonly KeyBinding[]): RegisterFn => {
 			if (handlers.length === 0) return;
 
 			// find first actionable handler
-			const handler = handlers.find(
-				(handler) => !handler.element || isInteractive(handler.element()),
-			);
+			const handler = handlers.find((handler) => {
+				if (
+					(handler.check && !handler.check()) ||
+					(handler.element && !isInteractive(handler.element()))
+				) {
+					return false;
+				}
+
+				return handler;
+			});
+
 			if (!handler) return;
 
 			e.preventDefault();
 			handler.callback();
 		};
-		document.addEventListener('keydown', handler, true);
-		return () => document.removeEventListener('keydown', handler, true);
+		document.addEventListener('keydown', keyboardEventHandler, true);
+		return () =>
+			document.removeEventListener('keydown', keyboardEventHandler, true);
 	}, []);
 
 	const register = useCallback((handler: ActivityHandler) => {

--- a/src/keybindings/utils.ts
+++ b/src/keybindings/utils.ts
@@ -43,7 +43,7 @@ export const focusIsInEditableArea = (): boolean => {
 	const active = getActiveElement(document);
 
 	if (!active) return false;
-	if (active.matches('input, textarea')) return true;
+	if (active.matches('input:not([type="checkbox"]), textarea')) return true;
 	if ('isContentEditable' in active && active.isContentEditable) {
 		return true;
 	}


### PR DESCRIPTION
Add check property function to key bindings activity handler + exclude checkbox from editable area focus check

[AB#14428](https://dev.azure.com/neovici/Cosmoz3/_workitems/edit/14428/)