### PR TITLE
feat: better invoke

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -29,16 +29,7 @@ export const once = <A extends Arr, R, F extends OnceFn<A, R> = OnceFn<A, R>>(
 	return (...args: A) => (result ??= check(args) ? fn(...args) : undefined);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type InvokedType<T> = T extends (...args: any[]) => infer R ? R : T;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type InvokedParameters<F> = F extends (...args: infer A) => any
-	? A
-	: never;
-
-export function invoke<F>(
-	fn: F,
-	...args: InvokedParameters<F>
-): InvokedType<F> {
-	return typeof fn === 'function' ? fn(...args) : fn;
-}
+export const invoke = <T, A extends unknown[]>(
+	fn: T | ((...args: A) => T),
+	...args: A
+) => (typeof fn === 'function' ? (fn as (...args: A) => T)(...args) : fn);


### PR DESCRIPTION
After reading up more on type inferrence, I realized that invoke was typed badly. We can 100% rely on typescript doing type inference without the need for conditional types. The missing piece was the type assertion inside of the `is function` branch. The old version had a problem in that it narrowed types too much. This version works exactly as you'd expect it, including enforcing the types of the function arguments.