### PR TITLE
fix: useStyleSheet cross-document support + useLayoutEffect

### DIFF
--- a/src/hooks/use-stylesheet.ts
+++ b/src/hooks/use-stylesheet.ts
@@ -6,7 +6,8 @@ export const useStyleSheet = (css: string) => {
 	const csRef = useRef<CSSStyleSheet | null>(null);
 	const getSheet = () => {
 		if (!csRef.current) {
-			csRef.current = new host.ownerDocument.defaultView.CSSStyleSheet();
+			const win = host.ownerDocument?.defaultView;
+			csRef.current = new win!.CSSStyleSheet();
 			host.shadowRoot!.adoptedStyleSheets = [
 				...host.shadowRoot!.adoptedStyleSheets,
 				csRef.current,

--- a/src/hooks/use-stylesheet.ts
+++ b/src/hooks/use-stylesheet.ts
@@ -1,18 +1,20 @@
-import { useEffect, useMemo } from '@pionjs/pion';
+import { useLayoutEffect, useRef } from '@pionjs/pion';
 import { useHost } from './use-host';
 
 export const useStyleSheet = (css: string) => {
 	const host = useHost();
-	const cs = useMemo(() => new CSSStyleSheet(), []);
-
-	useEffect(() => {
-		host.shadowRoot!.adoptedStyleSheets = [
-			...host.shadowRoot!.adoptedStyleSheets,
-			cs,
-		];
-	}, []);
-
-	useEffect(() => {
-		cs.replaceSync(css);
+	const csRef = useRef<CSSStyleSheet | null>(null);
+	const getSheet = () => {
+		if (!csRef.current) {
+			csRef.current = new host.ownerDocument.defaultView.CSSStyleSheet();
+			host.shadowRoot!.adoptedStyleSheets = [
+				...host.shadowRoot!.adoptedStyleSheets,
+				csRef.current,
+			];
+		}
+		return csRef.current;
+	};
+	useLayoutEffect(() => {
+		getSheet().replaceSync(css);
 	}, [css]);
 };


### PR DESCRIPTION
## Problem

Two issues with `useStyleSheet`:

1. **Cross-document**: `new CSSStyleSheet()` uses the parent window's global constructor. When the host element lives in a different document (e.g., a popup window), the created sheet has the wrong `[[ConstructorDocument]]` and is rejected by `adoptedStyleSheets`. Additionally, `useMemo` runs before `connectedCallback`, so `host.ownerDocument` may not yet reflect the target document.

2. **Timing race**: `useEffect` runs after the browser paints, causing a race condition with virtualizer measurements (e.g., `@lit-labs/virtualizer`) that determine item heights from rendered DOM. If the dynamic stylesheet (setting `.item { height: Npx }`) hasn't been applied when the virtualizer measures, items get incorrect heights.

## Fix

- Create `CSSStyleSheet` **lazily** inside `getSheet()`, called from `useLayoutEffect` — guarantees `host.ownerDocument` is correct (element is connected)
- Use `useLayoutEffect` instead of `useEffect` — applies styles before the browser paints, eliminating the measurement race
- Single `useLayoutEffect([css])` replaces both the mount effect and the update effect — `getSheet()` handles creation + appending on first call, subsequent calls just update via `replaceSync`

## Testing

Tested with `cosmoz-image-viewer` which opens a detached popup window rendering `cosmoz-autocomplete` (whose `cosmoz-listbox` uses `useStyleSheet` for dynamic item height styles). Without this fix, listbox items render with incorrect heights. With this fix, items are correctly sized.

Depends on pionjs/pion#136 for the `component()` static `adoptedStyleSheets` fix.