### PR TITLE
feat(hooks): extract usePersist hook from cosmoz-frontend

### DIFF
--- a/src/hooks/use-persist.ts
+++ b/src/hooks/use-persist.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useProperty } from '@pionjs/pion';
+
+type UsePersistResult = {
+	value: string;
+	setValue: (value: string) => void;
+	revalidate: () => string;
+};
+
+/**
+ * Hook to persist a string property to localStorage with cross-tab sync.
+ * Uses useProperty internally to make the value reactive to parent prop changes.
+ * When key is undefined, acts like a regular useProperty.
+ *
+ * @param property - property name on the host element
+ * @param key - localStorage key (if undefined, persistence is disabled)
+ * @param defaultValue - fallback value when no stored value exists
+ * @returns { value, setValue, revalidate }
+ */
+export const usePersist = (
+	property: string,
+	key: string | undefined,
+	defaultValue: string,
+): UsePersistResult => {
+	const [value, setValue] = useProperty<string>(property, () => {
+		if (!key) return defaultValue;
+		try {
+			return localStorage.getItem(key) ?? defaultValue;
+		} catch {
+			return defaultValue;
+		}
+	});
+
+	// Cross-tab sync via storage events (different browser windows)
+	useEffect(() => {
+		if (!key) return;
+
+		const handleStorage = (e: StorageEvent) => {
+			if (e.key === key && e.newValue) {
+				setValue(e.newValue);
+			}
+		};
+
+		window.addEventListener('storage', handleStorage);
+		return () => window.removeEventListener('storage', handleStorage);
+	}, [key]);
+
+	const setPersistedValue = useCallback(
+		(newValue: string) => {
+			setValue(newValue);
+			if (key) {
+				try {
+					localStorage.setItem(key, newValue);
+				} catch {
+					// Silently fail
+				}
+			}
+		},
+		[key],
+	);
+
+	const revalidate = useCallback((): string => {
+		if (!key) return value;
+		try {
+			const stored = localStorage.getItem(key);
+			if (stored != null && stored !== value) {
+				setValue(stored);
+				return stored;
+			}
+		} catch {
+			// Ignore
+		}
+		return value;
+	}, [key, value]);
+
+	return { value, setValue: setPersistedValue, revalidate };
+};

--- a/test/use-persist.test.ts
+++ b/test/use-persist.test.ts
@@ -1,0 +1,164 @@
+import { assert, fixture, html } from '@open-wc/testing';
+import { component } from '@pionjs/pion';
+import { spy } from 'sinon';
+import { usePersist } from '../src/hooks/use-persist';
+
+interface UsePersistElement extends HTMLElement {
+	value: string;
+	setValue: (v: string) => void;
+	revalidate: () => string;
+}
+
+// set a custom property on custom-webcomponent
+customElements.define(
+	'use-persist',
+	component((host) => {
+		const { value, setValue, revalidate } = usePersist(
+			'value',
+			'test-key',
+			'default',
+		);
+		(host as UsePersistElement).value = value;
+		(host as UsePersistElement).setValue = setValue;
+		(host as UsePersistElement).revalidate = revalidate;
+	}),
+);
+
+suite('usePersist', () => {
+	suite('with valid key', () => {
+		setup(() => localStorage.removeItem('test-key'));
+		teardown(() => localStorage.removeItem('test-key'));
+
+		test('returns default value when no stored value', async () => {
+			const result = (await fixture(
+				html`<use-persist></use-persist>`,
+			)) as UsePersistElement;
+			assert.equal(result.value, 'default');
+		});
+
+		test('returns stored value from localStorage', async () => {
+			localStorage.setItem('test-key', 'stored-value');
+			const result = (await fixture(
+				html`<use-persist></use-persist>`,
+			)) as UsePersistElement;
+			assert.equal(result.value, 'stored-value');
+		});
+
+		test('setValue persists to localStorage', async () => {
+			const result = (await fixture(
+				html`<use-persist></use-persist>`,
+			)) as UsePersistElement;
+			result.setValue('new-value');
+			assert.equal(localStorage.getItem('test-key'), 'new-value');
+		});
+
+		test('setValue updates the property', async () => {
+			const result = (await fixture(
+				html`<use-persist></use-persist>`,
+			)) as UsePersistElement;
+			result.setValue('new-value');
+			assert.equal(result.value, 'new-value');
+		});
+
+		test('revalidate returns stored value when different', async () => {
+			await fixture(html`<use-persist></use-persist>`);
+			localStorage.setItem('test-key', 'external-value');
+			const el = (await fixture(
+				html`<use-persist></use-persist>`,
+			)) as UsePersistElement;
+			const rev = el.revalidate();
+			assert.equal(rev, 'external-value');
+		});
+
+		test('revalidate returns current value when same', async () => {
+			const result = (await fixture(
+				html`<use-persist></use-persist>`,
+			)) as UsePersistElement;
+			result.setValue('my-value');
+			const rev = result.revalidate();
+			assert.equal(rev, 'my-value');
+		});
+
+		test('listens for cross-tab storage events', async () => {
+			const addSpy = spy(window, 'addEventListener');
+			const result = (await fixture(
+				html`<use-persist></use-persist>`,
+			)) as UsePersistElement;
+
+			assert.isTrue(addSpy.calledWith('storage'));
+			result.remove();
+
+			addSpy.restore();
+		});
+
+		test('updates value on storage event from another tab', async () => {
+			const result = (await fixture(
+				html`<use-persist></use-persist>`,
+			)) as UsePersistElement;
+			assert.equal(result.value, 'default');
+
+			// Simulate storage event
+			const event = new StorageEvent('storage', {
+				key: 'test-key',
+				newValue: 'cross-tab-value',
+			});
+			window.dispatchEvent(event);
+
+			await new Promise((r) => setTimeout(r, 10));
+			assert.equal(result.value, 'cross-tab-value');
+		});
+	});
+
+	suite('with undefined key (no persistence)', () => {
+		test('returns default value when key is undefined', async () => {
+			customElements.define(
+				'use-persist-no-key',
+				component((host) => {
+					const hook = usePersist as (
+						prop: string,
+						key: string | undefined,
+						defaultValue: string,
+					) => {
+						value: string;
+						setValue: (v: string) => void;
+						revalidate: () => string;
+					};
+					const { value, setValue, revalidate } = hook(
+						'value',
+						undefined,
+						'fallback',
+					);
+					(host as UsePersistElement).value = value;
+					(host as UsePersistElement).setValue = setValue;
+					(host as UsePersistElement).revalidate = revalidate;
+				}),
+			);
+			const result = (await fixture(
+				html`<use-persist-no-key></use-persist-no-key>`,
+			)) as UsePersistElement;
+			assert.equal(result.value, 'fallback');
+		});
+
+		test('setValue does not persist when key is undefined', async () => {
+			customElements.define(
+				'use-persist-no-key-set',
+				component((host) => {
+					const hook = usePersist as (
+						prop: string,
+						key: string | undefined,
+						defaultValue: string,
+					) => { value: string; setValue: (v: string) => void };
+					const { value, setValue } = hook('value', undefined, 'fallback');
+					(host as UsePersistElement).value = value;
+					(host as UsePersistElement).setValue = setValue;
+				}),
+			);
+			const result = (await fixture(
+				html`<use-persist-no-key-set></use-persist-no-key-set>`,
+			)) as UsePersistElement;
+			result.setValue('new-value');
+			assert.equal(result.value, 'new-value');
+			// No error thrown from localStorage
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Extract `usePersist` hook from cosmoz-frontend to cosmoz-utils for reuse
- Hook persists string values to localStorage with cross-tab sync
- Supports undefined key (disables persistence, acts like regular useProperty)

## Files
- `src/hooks/use-persist.ts` - New hook
- `test/use-persist.test.ts` - Tests

## Linked Issue
FE-640