### PR TITLE
fix(debounce$): stop amplifying rejections across pending promises

### DIFF
--- a/src/promise.ts
+++ b/src/promise.ts
@@ -83,29 +83,22 @@ export const limit$ = <T extends unknown[], P>(
 		});
 };
 
-type Pending<T, P> = Pick<Task<T, P>, 'resolve' | 'reject'>;
 export const debounce$ = <T extends unknown[], P>(
 	fn: (...args: T) => P | PromiseLike<P>,
 	ms?: number,
 ) => {
 	let timeoutId: ReturnType<typeof setTimeout>;
-	const pending: Pending<T, P>[] = [];
+	let resolve: ((value: P | PromiseLike<P>) => void) | null = null;
+	let reject: ((reason?: unknown) => void) | null = null;
 	return (...args: T): Promise<P> =>
 		new Promise((res, rej) => {
 			clearTimeout(timeoutId);
+			resolve = res;
+			reject = rej;
 			timeoutId = setTimeout(() => {
-				const currentPending = [...pending];
-				pending.length = 0;
-				Promise.resolve(fn(...args)).then(
-					(data) => {
-						currentPending.forEach(({ resolve }) => resolve(data));
-					},
-					(error) => {
-						currentPending.forEach(({ reject }) => reject(error));
-					},
-				);
+				Promise.resolve(fn(...args)).then(resolve, reject);
+				resolve = reject = null;
 			}, ms);
-			pending.push({ resolve: res, reject: rej });
 		});
 };
 

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -84,21 +84,57 @@ suite('debounce$', () => {
 		assert.isTrue(callback.called);
 	});
 
-	test('all debounced calls resolve with the same data', async () => {
+	test('only last debounced call resolves', async () => {
 		const fetch = (x) =>
 				new Promise((resolve) => requestAnimationFrame(() => resolve(x * 2))),
-			fetch$ = debounce$(fetch, 50),
-			result1 = fetch$(1);
+			fetch$ = debounce$(fetch, 50);
 
+		fetch$(1);
 		await nextFrame();
-
-		const result2 = fetch$(2);
-
+		fetch$(2);
 		await nextFrame();
 
 		const result3 = fetch$(3);
 
-		assert.deepEqual(await Promise.all([result1, result2, result3]), [6, 6, 6]);
+		assert.equal(await result3, 6);
+	});
+
+	test('superseded debounced calls do not settle', async () => {
+		const fetch = (x) =>
+				new Promise((resolve) => requestAnimationFrame(() => resolve(x * 2))),
+			fetch$ = debounce$(fetch, 50);
+
+		const result1 = fetch$(1);
+		await nextFrame();
+		fetch$(2);
+		await nextFrame();
+		fetch$(3);
+
+		let settled = false;
+		result1.then(() => {
+			settled = true;
+		});
+
+		await aTimeout(100);
+		assert.isFalse(settled, 'superseded promise should not settle');
+	});
+
+	test('only last call rejects on error', async () => {
+		const fail = () => Promise.reject(new Error('fail')),
+			fail$ = debounce$(fail, 50);
+
+		fail$(1);
+		await nextFrame();
+		fail$(2);
+		await nextFrame();
+		const result3 = fail$(3);
+
+		try {
+			await result3;
+			assert.fail('should have rejected');
+		} catch (e) {
+			assert.equal(e.message, 'fail');
+		}
 	});
 });
 


### PR DESCRIPTION
## Problem

`debounce$` accumulates all `{ resolve, reject }` pairs in a `pending[]` array and broadcasts the result/error to every one. When a single fetch fails, all N accumulated promises reject — amplifying 1 error into N unhandled rejections.

In production (FE-944), a single failed fetch on `/purchase/invoices/list-queue` produced **889 "Failed to fetch" exceptions in 1.2 seconds**.

## Root Cause

PR #100 (March 2022) introduced the `pending[]` broadcast pattern to fix a "memory leak" — the original `debounce$` only resolved the last promise, leaving earlier ones dangling. However:
- The original "leak" was never a real leak — dangling promises with no references are GC'd promptly
- The actual bug in the original was missing rejection handling (`resolve(fn(...args))` resolved with a rejected promise as a value instead of propagating the rejection)
- The broadcast pattern fixed rejection propagation but introduced error amplification

## Fix

Revert to the single `resolve`/`reject` pair approach — only the last pending promise settles. Earlier superseded promises never settle and are GC'd when consumers replace them (e.g., `useState`, `until()`), which happens on the next render cycle.

This is the same pattern used by `awesome-debounce-promise` (the most popular React-oriented debounce library).

```ts
// Before: broadcast to all pending promises
const pending: Pending<T, P>[] = [];
// ... pending.push({ resolve: res, reject: rej });
currentPending.forEach(({ reject }) => reject(error)); // N rejections!

// After: only last promise settles
let resolve: ((value: P | PromiseLike<P>) => void) | null = null;
let reject: ((reason?: unknown) => void) | null = null;
// ... resolve = res; reject = rej;
Promise.resolve(fn(...args)).then(resolve, reject); // 1 resolution or 1 rejection
```

## Impact

- **Error path**: 1 rejection instead of N (fixes FE-944)
- **Success path**: last caller resolves with data (same as before for the last caller; earlier callers no longer get a redundant stale resolution)
- **No `undefined`/`null` values** flow into consumers — stale promises simply never settle
- No consumer changes needed in cosmoz-frontend

## Tests

- Replaced broadcast test (`[6, 6, 6]`) with: only last resolves, superseded promises don't settle, only last rejects on error

Refs: FE-944