### PR TITLE
chore: add changeset for debounce$ rejection amplification fix

### DIFF
--- a/.changeset/fe-944-debounce-fix.md
+++ b/.changeset/fe-944-debounce-fix.md
@@ -1,0 +1,5 @@
+---
+'@neovici/cosmoz-utils': patch
+---
+
+fix(debounce$): stop amplifying rejections across pending promises


### PR DESCRIPTION
This PR adds the missing changeset for the debounce$ fix in #250.

Without this, changesets won't bump the version and won't publish to npm.

```md
---
"@neovici/cosmoz-utils": patch
---

fix(debounce$): stop amplifying rejections across pending promises
```

Refs: FE-944